### PR TITLE
Edit database connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
                 "command": "mysql.selectTop1000",
                 "title": "Select Top 1000",
                 "category": "MySQL"
+            },
+            {
+                "command": "mysql.editConnection",
+                "title": "Edit Connection",
+                "category": "MySQL"
             }
         ],
         "menus": {
@@ -100,7 +105,7 @@
                 {
                     "command": "mysql.deleteConnection",
                     "when": "view == mysql && viewItem == connection",
-                    "group": "mysql@2"
+                    "group": "mysql@3"
                 },
                 {
                     "command": "mysql.newQuery",
@@ -121,6 +126,11 @@
                     "command": "mysql.refresh",
                     "when": "view == mysql && viewItem == table",
                     "group": "mysql@1"
+                },
+                {
+                    "command": "mysql.editConnection",
+                    "when": "view == mysql && viewItem == connection",
+                    "group": "mysql@2"
                 }
             ]
         },

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -4,7 +4,10 @@ import * as fs from "fs";
 import * as mysql from "mysql";
 import * as vscode from "vscode";
 import { IConnection } from "../model/connection";
+import { ConnectionNode } from "../model/connectionNode";
+import { MySQLTreeDataProvider } from "../mysqlTreeDataProvider";
 import { AppInsightsClient } from "./appInsightsClient";
+import { Constants } from "./constants";
 import { Global } from "./global";
 import { OutputChannel } from "./outputChannel";
 
@@ -90,6 +93,26 @@ export class Utility {
             };
         }
         return mysql.createConnection(newConnectionOptions);
+    }
+
+    public static async editConnection(connectionNode: ConnectionNode, context: vscode.ExtensionContext, mysqlTreeDataProvider: MySQLTreeDataProvider) {
+        if (connectionNode) {
+            connectionNode.editConnection(context, mysqlTreeDataProvider);
+        } else {
+
+            const test = [];
+            const connections = context.globalState.get<{ [key: string]: IConnection }>(Constants.GlobalStateMySQLConectionsKey);
+            const ConnectionNodes = [];
+            if (connections) {
+                for (const id of Object.keys(connections)) {
+                    test[id] = connections[id].database;
+                }
+            }
+            const selectedConnection = await vscode.window.showQuickPick(test);
+            if (selectedConnection) {
+                selectedConnection.editConnection(context, mysqlTreeDataProvider);
+            }
+        }
     }
 
     private static async hasActiveConnection(): Promise<boolean> {

--- a/src/common/utility.ts
+++ b/src/common/utility.ts
@@ -99,6 +99,7 @@ export class Utility {
         if (connectionNode) {
             connectionNode.editConnection(context, mysqlTreeDataProvider);
         } else {
+            // No connection has been selected, let the user pick one
             const connections = context.globalState.get<{ [key: string]: IConnection }>(Constants.GlobalStateMySQLConectionsKey);
             const items: vscode.QuickPickItem[] = [];
 
@@ -121,45 +122,10 @@ export class Utility {
                 const selectedConnection = connections[selectedConnectionId];
 
                 if (selectedConnection !== undefined) {
-                    const host = await vscode.window.showInputBox({ prompt: "The hostname of the database", placeHolder: "host", ignoreFocusOut: true, value: selectedConnection.host });
-                    if (!host) {
-                        return;
-                    }
+                    const dummyNode = new ConnectionNode(selectedConnectionId, selectedConnection.host, selectedConnection.user, selectedConnection.password,
+                                                    selectedConnection.port, selectedConnection.certPath);
 
-                    const user = await vscode.window.showInputBox({ prompt: "The MySQL user to authenticate as", placeHolder: "user", ignoreFocusOut: true, value: selectedConnection.user });
-                    if (!user) {
-                        return;
-                    }
-
-                    const password = await vscode.window.showInputBox({ prompt: "The password of the MySQL user", placeHolder: "password",
-                                                                        ignoreFocusOut: true, password: true, value: selectedConnection.password });
-                    if (password === undefined) {
-                        return;
-                    }
-
-                    const port = await vscode.window.showInputBox({ prompt: "The port number to connect to", placeHolder: "port", ignoreFocusOut: true, value: selectedConnection.port });
-                    if (!port) {
-                        return;
-                    }
-
-                    const certPath = await vscode.window.showInputBox({ prompt: "[Optional] SSL certificate path. Leave empty to ignore", placeHolder: "certificate file path", ignoreFocusOut: true,
-                                                                        value: selectedConnection.certPath });
-                    if (certPath === undefined) {
-                        return;
-                    }
-
-                    connections[selectedConnectionId] = {
-                        host,
-                        user,
-                        port,
-                        certPath,
-                    };
-
-                    if (password) {
-                        await Global.keytar.setPassword(Constants.ExtensionId, selectedConnectionId, password);
-                    }
-                    await context.globalState.update(Constants.GlobalStateMySQLConectionsKey, connections);
-                    mysqlTreeDataProvider.refresh();
+                    dummyNode.editConnection(context, mysqlTreeDataProvider);
                 }
             });
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,6 +38,10 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand("mysql.selectTop1000", (tableNode: TableNode) => {
         tableNode.selectTop1000();
     }));
+
+    context.subscriptions.push(vscode.commands.registerCommand("mysql.editConnection", (connectionNode: ConnectionNode) => {
+        Utility.editConnection(connectionNode, this, mysqlTreeDataProvider);
+    }));
 }
 
 export function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand("mysql.deleteConnection", (connectionNode: ConnectionNode) => {
-        connectionNode.deleteConnection(context, mysqlTreeDataProvider);
+        Utility.deleteConnection(connectionNode, context, mysqlTreeDataProvider);
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand("mysql.runQuery", () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,7 @@ export function activate(context: vscode.ExtensionContext) {
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand("mysql.editConnection", (connectionNode: ConnectionNode) => {
-        Utility.editConnection(connectionNode, this, mysqlTreeDataProvider);
+        Utility.editConnection(connectionNode, context, mysqlTreeDataProvider);
     }));
 }
 

--- a/src/model/connectionNode.ts
+++ b/src/model/connectionNode.ts
@@ -93,7 +93,8 @@ export class ConnectionNode implements INode {
             return;
         }
 
-        const password = await vscode.window.showInputBox({ prompt: "The password of the MySQL user", placeHolder: "password", ignoreFocusOut: true, password: true, value: this.password });
+        const password = await vscode.window.showInputBox({ prompt: "The password of the MySQL user", placeHolder: "password",
+                                                            ignoreFocusOut: true, password: true, value: await Global.keytar.getPassword(Constants.ExtensionId, this.id) });
         if (password === undefined) {
             return;
         }


### PR DESCRIPTION
You can now edit a database connection, regardless if you right click it in the Tree or run the command "Edit Connection". If you run the command from the Command Palette, the user will have to select which MySQL connection he wants to edit. The same has been added for the "Delete Connection" command.