### PR TITLE
Escape database and table names

### DIFF
--- a/src/model/tableNode.ts
+++ b/src/model/tableNode.ts
@@ -47,7 +47,7 @@ export class TableNode implements INode {
 
     public async selectTop1000() {
         AppInsightsClient.sendEvent("selectTop1000");
-        const sql = `SELECT * FROM ${this.database}.${this.table} LIMIT 1000;`;
+        const sql = `SELECT * FROM \`${this.database}\`.\`${this.table}\` LIMIT 1000;`;
         Utility.createSQLTextDocument(sql);
 
         const connection = {


### PR DESCRIPTION
Use escaped literals in DB object names. 
For example, having a database with name 'my-database' will cause SQL Syntax Error, because of character '-'.