### PR TITLE
Remove keytar dependancy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,286 +1,345 @@
 {
     "name": "vscode-mysql",
     "version": "0.4.1",
-    "lockfileVersion": 1,
+    "lockfileVersion": 3,
     "requires": true,
-    "dependencies": {
-        "@types/keytar": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@types/keytar/-/keytar-4.0.1.tgz",
-            "integrity": "sha512-loKBID6UL4QjhD2scuvv6oAPlQ/WAY7aYTDyKlKo7fIgriLS8EZExqT567cHL5CY6si51MRoX1+r3mitD3eYrA==",
-            "dev": true
+    "packages": {
+        "": {
+            "name": "vscode-mysql",
+            "version": "0.4.1",
+            "dependencies": {
+                "applicationinsights": "^1.0.0",
+                "asciitable": "0.0.7",
+                "mysql": "^2.15.0",
+                "uuid": "^3.1.0"
+            },
+            "devDependencies": {
+                "@types/mocha": "^2.2.42",
+                "@types/node": "^7.10.14",
+                "@types/vscode": "^1.57.0",
+                "tslint": "^5.8.0",
+                "typescript": "^3.9.10"
+            },
+            "engines": {
+                "vscode": "^1.57.0"
+            }
         },
-        "@types/mocha": {
+        "node_modules/@types/mocha": {
             "version": "2.2.44",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.44.tgz",
             "integrity": "sha512-k2tWTQU8G4+iSMvqKi0Q9IIsWAp/n8xzdZS4Q4YVIltApoMA00wFBFdlJnmoaK1/z7B0Cy0yPe6GgXteSmdUNw==",
             "dev": true
         },
-        "@types/node": {
+        "node_modules/@types/node": {
             "version": "7.10.14",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.14.tgz",
             "integrity": "sha512-29GS75BE8asnTno3yB6ubOJOO0FboExEqNJy4bpz0GSmW/8wPTNL4h9h63c6s1uTrOopCmJYe/4yJLh5r92ZUA==",
             "dev": true
         },
-        "@types/vscode": {
+        "node_modules/@types/vscode": {
             "version": "1.58.1",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.58.1.tgz",
             "integrity": "sha512-sa76rDXiSif09he8KoaWWUQxsuBr2+uND0xn1GUbEODkuEjp2p7Rqd3t5qlvklfmAedLFdL7MdnsPa57uzwcOw==",
             "dev": true
         },
-        "ansi-regex": {
+        "node_modules/ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "ansi-styles": {
+        "node_modules/ansi-styles": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "applicationinsights": {
+        "node_modules/applicationinsights": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.0.tgz",
             "integrity": "sha1-9ZQuU/hh2miB8kJGBonDRPg1hHM=",
-            "requires": {
+            "dependencies": {
                 "diagnostic-channel": "0.2.0",
                 "diagnostic-channel-publishers": "0.2.1",
                 "zone.js": "0.7.6"
             }
         },
-        "asciitable": {
+        "node_modules/asciitable": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/asciitable/-/asciitable-0.0.7.tgz",
             "integrity": "sha1-e8zERZjmHhkqgAtyXAYSobF3pW4="
         },
-        "babel-code-frame": {
+        "node_modules/babel-code-frame": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "chalk": "^1.1.3",
                 "esutils": "^2.0.2",
                 "js-tokens": "^3.0.2"
             }
         },
-        "balanced-match": {
+        "node_modules/balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
         },
-        "bignumber.js": {
+        "node_modules/bignumber.js": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.0.4.tgz",
-            "integrity": "sha512-LDXpJKVzEx2/OqNbG9mXBNvHuiRL4PzHCGfnANHMJ+fv68Ads3exDVJeGDJws+AoNEuca93bU3q+S0woeUaCdg=="
+            "integrity": "sha512-LDXpJKVzEx2/OqNbG9mXBNvHuiRL4PzHCGfnANHMJ+fv68Ads3exDVJeGDJws+AoNEuca93bU3q+S0woeUaCdg==",
+            "engines": {
+                "node": "*"
+            }
         },
-        "brace-expansion": {
+        "node_modules/brace-expansion": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
-        "builtin-modules": {
+        "node_modules/builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "chalk": {
+        "node_modules/chalk": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "ansi-styles": "^2.2.1",
                 "escape-string-regexp": "^1.0.2",
                 "has-ansi": "^2.0.0",
                 "strip-ansi": "^3.0.0",
                 "supports-color": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "color-convert": {
+        "node_modules/color-convert": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "color-name": "^1.1.1"
             }
         },
-        "color-name": {
+        "node_modules/color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
-        "commander": {
+        "node_modules/commander": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
             "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
             "dev": true
         },
-        "concat-map": {
+        "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
-        "core-util-is": {
+        "node_modules/core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
-        "diagnostic-channel": {
+        "node_modules/diagnostic-channel": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
             "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
-            "requires": {
+            "dependencies": {
                 "semver": "^5.3.0"
             }
         },
-        "diagnostic-channel-publishers": {
+        "node_modules/diagnostic-channel-publishers": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.2.1.tgz",
-            "integrity": "sha1-ji1geottef6IC1SLxYzGvrKIxPM="
+            "integrity": "sha1-ji1geottef6IC1SLxYzGvrKIxPM=",
+            "peerDependencies": {
+                "diagnostic-channel": "*"
+            }
         },
-        "diff": {
+        "node_modules/diff": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
             "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
         },
-        "escape-string-regexp": {
+        "node_modules/escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
         },
-        "esutils": {
+        "node_modules/esutils": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "fs.realpath": {
+        "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
-        "glob": {
+        "node_modules/glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
                 "inherits": "2",
                 "minimatch": "^3.0.4",
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
             }
         },
-        "has-ansi": {
+        "node_modules/has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "has-flag": {
+        "node_modules/has-flag": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "inflight": {
+        "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
             }
         },
-        "inherits": {
+        "node_modules/inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
-        "isarray": {
+        "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
-        "js-tokens": {
+        "node_modules/js-tokens": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
             "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
             "dev": true
         },
-        "minimatch": {
+        "node_modules/minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
-        "mysql": {
+        "node_modules/mysql": {
             "version": "2.15.0",
             "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.15.0.tgz",
             "integrity": "sha512-C7tjzWtbN5nzkLIV+E8Crnl9bFyc7d3XJcBAvHKEVkjrYjogz3llo22q6s/hw+UcsE4/844pDob9ac+3dVjQSA==",
-            "requires": {
+            "dependencies": {
                 "bignumber.js": "4.0.4",
                 "readable-stream": "2.3.3",
                 "safe-buffer": "5.1.1",
                 "sqlstring": "2.3.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
-        "once": {
+        "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "wrappy": "1"
             }
         },
-        "path-is-absolute": {
+        "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "path-parse": {
+        "node_modules/path-parse": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
             "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
             "dev": true
         },
-        "process-nextick-args": {
+        "node_modules/process-nextick-args": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
-        "readable-stream": {
+        "node_modules/readable-stream": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
             "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-            "requires": {
+            "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
                 "isarray": "~1.0.0",
@@ -290,65 +349,77 @@
                 "util-deprecate": "~1.0.1"
             }
         },
-        "resolve": {
+        "node_modules/resolve": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
             "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "path-parse": "^1.0.5"
             }
         },
-        "safe-buffer": {
+        "node_modules/safe-buffer": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
             "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
-        "semver": {
+        "node_modules/semver": {
             "version": "5.4.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-            "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+            "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+            "bin": {
+                "semver": "bin/semver"
+            }
         },
-        "sqlstring": {
+        "node_modules/sqlstring": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.0.tgz",
-            "integrity": "sha1-UluKT9Jtb3GqYegipsr5dtMa0qg="
+            "integrity": "sha1-UluKT9Jtb3GqYegipsr5dtMa0qg=",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
-        "string_decoder": {
+        "node_modules/string_decoder": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
             "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-            "requires": {
+            "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
         },
-        "strip-ansi": {
+        "node_modules/strip-ansi": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
-        "supports-color": {
+        "node_modules/supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
         },
-        "tslib": {
+        "node_modules/tslib": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
             "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg==",
             "dev": true
         },
-        "tslint": {
+        "node_modules/tslint": {
             "version": "5.8.0",
             "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
             "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "babel-code-frame": "^6.22.0",
                 "builtin-modules": "^1.1.1",
                 "chalk": "^2.1.0",
@@ -361,70 +432,100 @@
                 "tslib": "^1.7.1",
                 "tsutils": "^2.12.1"
             },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                    "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-                    "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.1.0",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^4.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^2.0.0"
-                    }
-                }
+            "bin": {
+                "tslint": "bin/tslint"
+            },
+            "engines": {
+                "node": ">=4.1.2"
+            },
+            "peerDependencies": {
+                "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev"
             }
         },
-        "tsutils": {
+        "node_modules/tslint/node_modules/ansi-styles": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+            "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/tslint/node_modules/chalk": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+            "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/tslint/node_modules/supports-color": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+            "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/tsutils": {
             "version": "2.12.2",
             "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.2.tgz",
             "integrity": "sha1-rVikhl0X7D3bZjG2ylO+FKVlb/M=",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "tslib": "^1.7.1"
+            },
+            "peerDependencies": {
+                "typescript": ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >= 2.4.0-dev || >= 2.5.0-dev || >= 2.6.0-dev || >= 2.7.0-dev || >= 2.8.0-dev"
             }
         },
-        "typescript": {
+        "node_modules/typescript": {
             "version": "3.9.10",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
             "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-            "dev": true
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
         },
-        "util-deprecate": {
+        "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
-        "uuid": {
+        "node_modules/uuid": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-            "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+            "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "bin": {
+                "uuid": "bin/uuid"
+            }
         },
-        "wrappy": {
+        "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
         },
-        "zone.js": {
+        "node_modules/zone.js": {
             "version": "0.7.6",
             "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.7.6.tgz",
             "integrity": "sha1-+7w50+AmHQmG8boGMG6zrrDSIAk="

--- a/package.json
+++ b/package.json
@@ -168,7 +168,6 @@
         "tslint": "tslint -t verbose src/**/*.ts"
     },
     "devDependencies": {
-        "@types/keytar": "^4.0.1",
         "@types/mocha": "^2.2.42",
         "@types/node": "^7.10.14",
         "@types/vscode": "^1.57.0",

--- a/src/common/global.ts
+++ b/src/common/global.ts
@@ -1,10 +1,9 @@
 "use strict";
-import * as keytarType from "keytar";
 import * as vscode from "vscode";
 import { IConnection } from "../model/connection";
 
 export class Global {
-    public static keytar: typeof keytarType = getCoreNodeModule(`keytar`);
+    public static secrets: vscode.SecretStorage;
 
     static get activeConnection(): IConnection {
         return Global._activeConnection;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,11 +7,15 @@ import { DatabaseNode } from "./model/databaseNode";
 import { INode } from "./model/INode";
 import { TableNode } from "./model/tableNode";
 import { MySQLTreeDataProvider } from "./mysqlTreeDataProvider";
+import { Global } from "./common/global";
 
 export function activate(context: vscode.ExtensionContext) {
     AppInsightsClient.sendEvent("loadExtension");
 
     const mysqlTreeDataProvider = new MySQLTreeDataProvider(context);
+    
+    Global.secrets = context.secrets;
+
     context.subscriptions.push(vscode.window.registerTreeDataProvider("mysql", mysqlTreeDataProvider));
 
     context.subscriptions.push(vscode.commands.registerCommand("mysql.refresh", (node: INode) => {

--- a/src/model/connectionNode.ts
+++ b/src/model/connectionNode.ts
@@ -66,7 +66,7 @@ export class ConnectionNode implements INode {
         delete connections[this.id];
         await context.globalState.update(Constants.GlobalStateMySQLConectionsKey, connections);
 
-        await Global.keytar.deletePassword(Constants.ExtensionId, this.id);
+        await Global.secrets.delete(this.id);
 
         mysqlTreeDataProvider.refresh();
     }

--- a/src/mysqlTreeDataProvider.ts
+++ b/src/mysqlTreeDataProvider.ts
@@ -69,7 +69,7 @@ export class MySQLTreeDataProvider implements vscode.TreeDataProvider<INode> {
         };
 
         if (password) {
-            await Global.keytar.setPassword(Constants.ExtensionId, id, password);
+            await Global.secrets.store(id, password);
         }
         await this.context.globalState.update(Constants.GlobalStateMySQLConectionsKey, connections);
         this.refresh();
@@ -85,7 +85,7 @@ export class MySQLTreeDataProvider implements vscode.TreeDataProvider<INode> {
         const ConnectionNodes = [];
         if (connections) {
             for (const id of Object.keys(connections)) {
-                const password = await Global.keytar.getPassword(Constants.ExtensionId, id);
+                const password = await Global.secrets.get(id);
                 ConnectionNodes.push(new ConnectionNode(id, connections[id].host, connections[id].user, password, connections[id].port, connections[id].certPath));
                 if (!Global.activeConnection) {
                     Global.activeConnection = {


### PR DESCRIPTION
This fixes vscode-mysql in VSCode v1.83.0 where keytar is removed from the default VSCode dependancy tree.

- Replaces keytar with SecretStorage